### PR TITLE
🎨Remove extra padding when no icon

### DIFF
--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -36,7 +36,7 @@ const Input = ({ name, ...props }) => {
               readonly={readonly}
               size={size}
               icon={!!icon}
-              iconPosition={iconPosition}
+              iconPosition={icon && iconPosition}
               css={{
                 '.ui.form .fields .field &.ui.input input, .ui.form .field &.ui.input input': {
                   width: '100%',


### PR DESCRIPTION
There's extra padding in the Input even when there's no icon specified.
This is because of `iconPosition.defaultProp = 'left'`
As long as iconPosition is specified, the "icon" class will be added to Input, and will cause
```
ui[class*="left icon"].input > input {
    padding-left: 2.67142857em !important;
    padding-right: 1em !important;
}
```
to be applied