### PR TITLE
⚡️Add CSS formatting and fix extra padding

### DIFF
--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -36,7 +36,7 @@ const Input = ({ name, ...props }) => {
               readonly={readonly}
               size={size}
               icon={!!icon}
-              iconPosition={iconPosition}
+              iconPosition={icon && iconPosition}
               css={{
                 '.ui.form .fields .field &.ui.input input, .ui.form .field &.ui.input input': {
                   width: '100%',
@@ -86,7 +86,7 @@ const Input = ({ name, ...props }) => {
                     disabled={disabled}
                     size={size}
                     icon={!!icon}
-                    iconPosition={iconPosition}
+                    iconPosition={icon && iconPosition}
                     css={{
                       '.ui.form .fields .field &.ui.input input, .ui.form .field &.ui.input input': {
                         width: '100%',

--- a/src/index.js
+++ b/src/index.js
@@ -13,10 +13,11 @@ const useReduxForm = memoize(({ layout, config }) => {
     );
   }
   /* Header */
-  const renderHeader = ({ items, style, className, formProps }) => (
+  const renderHeader = ({ items, style, css, className, formProps }) => (
     // TODO: Open wrapper for Header
     <div
       style={{ display: 'flex', marginBottom: 50, ...style }}
+      css={css}
       className={className}
     >
       {items.map(({ id: itemKey, component, render, ...itemProps }) => {
@@ -49,6 +50,7 @@ const useReduxForm = memoize(({ layout, config }) => {
   );
   renderHeader.defaultProps = {
     style: null,
+    css: null,
     className: '',
   };
   renderHeader.propTypes = {
@@ -62,6 +64,7 @@ const useReduxForm = memoize(({ layout, config }) => {
       }),
     ).isRequired,
     style: PropTypes.object, // eslint-disable-line
+    css: PropTypes.object, // eslint-disable-line
     className: PropTypes.string,
     formProps: PropTypes.object.isRequired, // eslint-disable-line
   };
@@ -139,37 +142,43 @@ const useReduxForm = memoize(({ layout, config }) => {
   };
 
   /* Body */
-  const renderBody = ({ sections, formProps }) =>
-    sections.map(({ component, render, ...sectionProps }) => {
-      if (component) {
-        return createElement(
-          component,
-          {
-            key: sectionProps.id || sectionProps.name,
-            ...sectionProps,
-            formProps,
-          },
-          renderSection({ ...sectionProps, formProps }),
-        );
-      }
-      if (render) {
-        return (
-          <div key={sectionProps.id || sectionProps.name}>
-            {render({
+  const renderBody = ({ css, className, sections, formProps }) => (
+    <div css={css} className={className}>
+      {sections.map(({ component, render, ...sectionProps }) => {
+        if (component) {
+          return createElement(
+            component,
+            {
+              key: sectionProps.id || sectionProps.name,
               ...sectionProps,
               formProps,
-              children: renderSection({ ...sectionProps, formProps }),
-            })}
-          </div>
-        );
-      }
-      return createElement(renderSection, {
-        key: sectionProps.id || sectionProps.name,
-        ...sectionProps,
-        formProps,
-      });
-    });
-  renderBody.defaultProps = {};
+            },
+            renderSection({ ...sectionProps, formProps }),
+          );
+        }
+        if (render) {
+          return (
+            <div key={sectionProps.id || sectionProps.name}>
+              {render({
+                ...sectionProps,
+                formProps,
+                children: renderSection({ ...sectionProps, formProps }),
+              })}
+            </div>
+          );
+        }
+        return createElement(renderSection, {
+          key: sectionProps.id || sectionProps.name,
+          ...sectionProps,
+          formProps,
+        });
+      })}
+    </div>
+  );
+  renderBody.defaultProps = {
+    css: null,
+    className: '',
+  };
   renderBody.propTypes = {
     sections: PropTypes.arrayOf(
       PropTypes.shape({
@@ -191,13 +200,16 @@ const useReduxForm = memoize(({ layout, config }) => {
       }),
     ).isRequired,
     formProps: PropTypes.object.isRequired, // eslint-disable-line
+    css: PropTypes.object, // eslint-disable-line
+    className: PropTypes.string,
   };
 
   /* Footer */
-  const renderFooter = ({ items, style, className, formProps }) => (
+  const renderFooter = ({ items, style, css, className, formProps }) => (
     // TODO: Open wrapper for Header
     <div
       style={{ display: 'flex', marginTop: 50, ...style }}
+      css={css}
       className={className}
     >
       {items.map(({ id: itemKey, component, render, ...itemProps }) => {
@@ -230,6 +242,7 @@ const useReduxForm = memoize(({ layout, config }) => {
   );
   renderFooter.defaultProps = {
     style: null,
+    css: null,
     className: '',
   };
   renderFooter.propTypes = {
@@ -243,6 +256,7 @@ const useReduxForm = memoize(({ layout, config }) => {
       }),
     ).isRequired,
     style: PropTypes.object, // eslint-disable-line
+    css: PropTypes.object, // eslint-disable-line
     className: PropTypes.string,
     formProps: PropTypes.object.isRequired, // eslint-disable-line
   };


### PR DESCRIPTION
1) Add CSS prop for header, body and footer
2) Fix the extra padding around Input

The extra padding is caused by `iconPosition.defaultProp = 'left'`
As long as iconPosition is specified, the "icon" class will be added to Input, and will cause
```
ui[class*="left icon"].input > input {
    padding-left: 2.67142857em !important;
    padding-right: 1em !important;
}
```
to be applied