### PR TITLE
🎨Remove default size large for components in form

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -317,7 +317,7 @@ const useReduxForm = memoize(({ layout, config }) => {
   };
   form.defaultProps = {
     autoComplete: 'off',
-    size: 'large',
+    size: null,
     formProps: {},
     style: null,
     className: '',


### PR DESCRIPTION
Remove the default size=large
I think this change makes sense since the defaultProp value of size inside components is
```
  size: null, // ? no supply means 'medium' in semantic-ui
```
So this will keep the size consistently null instead of setting them to large.