### PR TITLE
🐞Fix cannot upload same file twice

### DIFF
--- a/src/components/FileInput.js
+++ b/src/components/FileInput.js
@@ -40,6 +40,12 @@ const FileInput = ({
         ref={fileInputRef}
         type="file"
         accept={accept}
+        onClick={e => {
+          // * onChange is not fired when the same file is uploaded twice,
+          // * so this clears the current file on click, to allow onChange to fire.
+          // * There is no other React specific way of controlling file inputs
+          e.target.value = '';
+        }}
         onChange={e => {
           if (e.target.files?.[0]) {
             onChange(e.target.files?.[0]);


### PR DESCRIPTION
**Bug**
When uploading a file, clearing the form and then uploading the same file again, that file cannot be uploaded.
or
After uploading a file, if I try to upload the same file again that file is not uploaded.

**Cause**
Because the same file is being uploaded, onChange does not fire, so the file does not get reuploaded.

**Fix**
Clear the input value on click, so that onChange will fire

https://stackoverflow.com/questions/42192346/how-to-reset-reactjs-file-input